### PR TITLE
Fix for find_maximean_sequence

### DIFF
--- a/src/diversity_sequence.jl
+++ b/src/diversity_sequence.jl
@@ -98,7 +98,7 @@ function find_maximean_sequence(dm::AbstractMatrix{Float64}, maxsize::I = size(d
     while length(selected) < min(maxsize, N)
         # Find the unselected one with maximum sum distance to selected ones
         idx = first(unselected)
-        for i in 2:length(unselected)
+        for i in unselected
             if sumdistances[i] > sumdistances[idx]
                 idx = i
             end

--- a/test/test_diversity_sequence.jl
+++ b/test/test_diversity_sequence.jl
@@ -52,8 +52,7 @@ end
     o = seq.order
     @test in(o, [[1, 3, 2, 4], [3, 1, 2, 4], [1, 4, 3, 2], [4, 1, 3, 2]])
 
-    # Distance Matrix for the next case below. Using Jaccard (2)
-    # Used Levenshtein since its easier to debug, and skip qgram sizes
+    # Using Levenshtein since its easier to debug, and skip qgram sizes
     other_objects = ["Hello", "Helo", "Oi", "Ola", "Heja"]
     sequence = MaxiMeanDiversitySequence(Levenshtein(), other_objects)
     object_ranking = sequence.order
@@ -71,6 +70,7 @@ end
 end
 
 @testset "Right matrix removal order" begin
+#Example of a distance matrix that throws exception in the divseq algorithm
 dm = [[0.0, 5.0, 10.0, 2.0, 1.0] [5.0, 0.0, 7.0, 1.0, 1.0] [10.0, 7.0, 0.0 ,1.0, 1.0] [ 2.0, 1.0, 1.0 ,0.0, 1.0] [ 2.0, 1.0, 1.0 ,1.0, 0.0]]
 object_ranking = find_maximean_sequence(dm)     
 @test in(object_ranking, [[1,3,2,4,5], [3,1,2,4,5]])

--- a/test/test_diversity_sequence.jl
+++ b/test/test_diversity_sequence.jl
@@ -1,5 +1,5 @@
 using MultiDistances: MaxiMinDiversitySequence, DiversitySequence
-using MultiDistances: MaxiMeanDiversitySequence
+using MultiDistances: MaxiMeanDiversitySequence, find_maximean_sequence
 
 has_same_elements(a, b) = (length(a) == length(b)) && all(be -> in(be, a), b)
 
@@ -51,12 +51,29 @@ end
     # so the maximean sequence should be one of: [1, 3, 2, 4] or [3, 1, 2, 4] or [1, 4, 3, 2] or [4, 1, 3, 2]
     o = seq.order
     @test in(o, [[1, 3, 2, 4], [3, 1, 2, 4], [1, 4, 3, 2], [4, 1, 3, 2]])
+
+    # Distance Matrix for the next case below. Using Jaccard (2)
+    # Used Levenshtein since its easier to debug, and skip qgram sizes
+    other_objects = ["Hello", "Helo", "Oi", "Ola", "Heja"]
+    sequence = MaxiMeanDiversitySequence(Levenshtein(), other_objects)
+    object_ranking = sequence.order
+    # The first pair (highest distance) is added to first,
+    # and it could be: [a,b] or [b,a]
+    # Expected Result: ["Oi", "Hello", "Heja", "Ola", "Helo"]
+    @test in(object_ranking, [[3,1,5,4,2], [1,3,5,4,2]])
+
 end
 
 @testset "Few objects" begin
     d = Jaccard(2)
     @test_throws AssertionError MaxiMinDiversitySequence(d, [1])
     @test_throws AssertionError MaxiMeanDiversitySequence(d, [1])
+end
+
+@testset "Right matrix removal order" begin
+dm = [[0.0, 5.0, 10.0, 2.0, 1.0] [5.0, 0.0, 7.0, 1.0, 1.0] [10.0, 7.0, 0.0 ,1.0, 1.0] [ 2.0, 1.0, 1.0 ,0.0, 1.0] [ 2.0, 1.0, 1.0 ,1.0, 0.0]]
+object_ranking = find_maximean_sequence(dm)     
+@test in(object_ranking, [[1,3,2,4,5], [3,1,2,4,5]])
 end
 
 end


### PR DESCRIPTION
The for loop in divseq MaxiMean iterates over a sequence (2:length(list)), that will then be the columns of the matrix. It needs a matrix with more than 5 columns to trigger this issue.

Before: `for i in 2:length(unselected) #Iterates on indices, always starting at 2` 
After: `for i in unselected #Iterates on whichever elements are still unselected`

**Example: For a matrix with 5 columns**
Let's say, the first pick are 2 and 3, then `unselected = [1, 4, 5]`. You should then compare the columns 1, 4 and 5 of the matrix. Instead, the current version will compare columns 1, 2 and 3. 

So, the `for loop` **should iterate on elements**, and **not on indices** of the "unselected" set.

I added two test cases to test/test_diversity_sequence. One that triggered an Exception, and another with the right expected output sequence.